### PR TITLE
게시물 단건조회 API 설계 및 서비스로직테스트 케이스 작성

### DIFF
--- a/src/main/java/com/springstudy/myspringstudy/controller/PostController.java
+++ b/src/main/java/com/springstudy/myspringstudy/controller/PostController.java
@@ -1,13 +1,12 @@
 package com.springstudy.myspringstudy.controller;
 
+import com.springstudy.myspringstudy.domain.Post;
 import com.springstudy.myspringstudy.dto.request.PostCreate;
 import com.springstudy.myspringstudy.service.PostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @Slf4j
@@ -19,5 +18,10 @@ public class PostController {
     @PostMapping("/posts")
     public void post(@RequestBody @Valid PostCreate request) throws Exception {
         postService.write(request);
+    }
+
+    @GetMapping("/posts/{postId}")
+    public Post get(@PathVariable("postId") Long id) {
+        return postService.get(id);
     }
 }

--- a/src/main/java/com/springstudy/myspringstudy/service/PostService.java
+++ b/src/main/java/com/springstudy/myspringstudy/service/PostService.java
@@ -22,4 +22,11 @@ public class PostService {
 
         postRepository.save(post);
     }
+
+    public Post get(Long id) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("글이 존재하지 않습니다."));
+
+        return post;
+    }
 }

--- a/src/test/java/com/springstudy/myspringstudy/service/PostServiceTest.java
+++ b/src/test/java/com/springstudy/myspringstudy/service/PostServiceTest.java
@@ -1,0 +1,98 @@
+package com.springstudy.myspringstudy.service;
+
+import com.springstudy.myspringstudy.domain.Post;
+import com.springstudy.myspringstudy.dto.request.PostCreate;
+import com.springstudy.myspringstudy.repository.PostRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PostServiceTest {
+
+    @Autowired
+    private PostService postService;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @BeforeEach
+    void clean() {
+        postRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("글 작성이 잘 되는지")
+    void test1() {
+        // given
+        PostCreate request = PostCreate.builder()
+                .title("제목목")
+                .content("내용용")
+                .build();
+        //when
+        postService.write(request);
+
+        //then
+        assertEquals(1L, postRepository.count());
+        Post post = postRepository.findAll().get(0);
+        assertEquals("제목목", post.getTitle());
+        assertEquals("내용용", post.getContent());
+    }
+
+    @Test
+    @DisplayName("글 1개 조회")
+    void test2() {
+        // given
+        Post savePost = Post.builder()
+                .title("ㅎㅇ")
+                .content("ㅎㅇㅎㅇ")
+                .build();
+        postRepository.save(savePost);
+
+        // when
+        Post post = postService.get(savePost.getId());
+
+        // then
+        assertNotNull(post);
+        assertEquals(1L, postRepository.count());
+        assertEquals("ㅎㅇ", post.getTitle());
+        assertEquals("ㅎㅇㅎㅇ", post.getContent());
+    }
+
+    @Test
+    @DisplayName("글 1개 조회")
+    void test4() throws Exception {
+        // given
+        Post post = Post.builder()
+                .title("ㅎㅇㅎㅇ")
+                .content("ㅎㅇ")
+                .build();
+
+        postRepository.save(post);
+
+        // expected
+        mockMvc.perform(get("/posts/{postId}", post.getId())
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(post.getId()))
+                .andExpect(jsonPath("$.title").value("ㅎㅇㅎㅇ"))
+                .andExpect(jsonPath("$.content").value("ㅎㅇ"))
+                .andDo(print());
+
+    }
+}


### PR DESCRIPTION
게시물이 잘 작성 되는지
<img width="592" alt="스크린샷 2024-07-03 오후 5 41 45" src="https://github.com/mr6208/MySpring/assets/93671010/d8878ef6-54dc-4f0b-9cb5-528ab41815f1">

단건조회 로직이 정상적으로 작동되는지
<img width="595" alt="스크린샷 2024-07-03 오후 5 42 32" src="https://github.com/mr6208/MySpring/assets/93671010/e713d94d-3dc4-4a53-b61d-4644b6878165">

컨트롤러의 단건조회 요청을 정상적으로 수행하는지
<img width="842" alt="스크린샷 2024-07-03 오후 5 42 59" src="https://github.com/mr6208/MySpring/assets/93671010/66031048-a041-4552-b101-54948bc03452">

1. 테스팅을 위해 Post 엔티티 내부의 빌더패턴 사용(생성자)후 게시물 저장
2. junit 테스트 + mockMvc + jsonPath를 이용해 컨트롤러 내부의 단건조회 API 호출 및 게시물의 데이터 일치 판별
