### PR TITLE
응답 객체 분리 및 반환객체 변경

### DIFF
--- a/src/main/java/com/springstudy/myspringstudy/controller/PostController.java
+++ b/src/main/java/com/springstudy/myspringstudy/controller/PostController.java
@@ -1,7 +1,7 @@
 package com.springstudy.myspringstudy.controller;
 
-import com.springstudy.myspringstudy.domain.Post;
 import com.springstudy.myspringstudy.dto.request.PostCreate;
+import com.springstudy.myspringstudy.dto.response.PostResponse;
 import com.springstudy.myspringstudy.service.PostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +21,7 @@ public class PostController {
     }
 
     @GetMapping("/posts/{postId}")
-    public Post get(@PathVariable("postId") Long id) {
+    public PostResponse get(@PathVariable("postId") Long id) {
         return postService.get(id);
     }
 }

--- a/src/main/java/com/springstudy/myspringstudy/dto/response/PostResponse.java
+++ b/src/main/java/com/springstudy/myspringstudy/dto/response/PostResponse.java
@@ -1,0 +1,18 @@
+package com.springstudy.myspringstudy.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PostResponse {
+    private final Long id;
+    private final String title;
+    private final String content;
+
+    @Builder
+    public PostResponse(Long id, String title, String content) {
+        this.id = id;
+        this.title = title.substring(0, Math.min(title.length(), 10));
+        this.content = content;
+    }
+}

--- a/src/main/java/com/springstudy/myspringstudy/service/PostService.java
+++ b/src/main/java/com/springstudy/myspringstudy/service/PostService.java
@@ -2,6 +2,7 @@ package com.springstudy.myspringstudy.service;
 
 import com.springstudy.myspringstudy.domain.Post;
 import com.springstudy.myspringstudy.dto.request.PostCreate;
+import com.springstudy.myspringstudy.dto.response.PostResponse;
 import com.springstudy.myspringstudy.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,10 +24,16 @@ public class PostService {
         postRepository.save(post);
     }
 
-    public Post get(Long id) {
+    public PostResponse get(Long id) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("글이 존재하지 않습니다."));
 
-        return post;
+        PostResponse response = PostResponse.builder()
+                .title(post.getTitle())
+                .id(post.getId())
+                .content(post.getContent())
+                .build();
+
+        return response;
     }
 }

--- a/src/test/java/com/springstudy/myspringstudy/controller/PostControllerTest.java
+++ b/src/test/java/com/springstudy/myspringstudy/controller/PostControllerTest.java
@@ -55,7 +55,6 @@ class PostControllerTest {
                         .content(json)
                 )
                 .andExpect(status().isOk())
-                .andExpect(content().string("{}"))
                 .andDo(print());
 
     }
@@ -109,5 +108,28 @@ class PostControllerTest {
         Post post = postRepository.findAll().get(0);
         assertEquals("제목이다", post.getTitle());
         assertEquals("내용용", post.getContent());
+    }
+
+    @Test
+    @DisplayName("글 1개 조회")
+    void test4() throws Exception {
+        // given
+        Post post = Post.builder()
+                .title("123456789012345")
+                .content("ㅎㅇ")
+                .build();
+
+        // 서버에서 제목을 최대 10글자만 반환하도록 해주세요
+        postRepository.save(post);
+
+        // expected
+        mockMvc.perform(get("/posts/{postId}", post.getId())
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(post.getId()))
+                .andExpect(jsonPath("$.title").value("1234567890"))
+                .andExpect(jsonPath("$.content").value("ㅎㅇ"))
+                .andDo(print());
+
     }
 }

--- a/src/test/java/com/springstudy/myspringstudy/service/PostServiceTest.java
+++ b/src/test/java/com/springstudy/myspringstudy/service/PostServiceTest.java
@@ -2,6 +2,7 @@ package com.springstudy.myspringstudy.service;
 
 import com.springstudy.myspringstudy.domain.Post;
 import com.springstudy.myspringstudy.dto.request.PostCreate;
+import com.springstudy.myspringstudy.dto.response.PostResponse;
 import com.springstudy.myspringstudy.repository.PostRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -12,11 +13,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.springframework.http.MediaType.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -65,34 +61,12 @@ class PostServiceTest {
         postRepository.save(savePost);
 
         // when
-        Post post = postService.get(savePost.getId());
+        PostResponse postResponse = postService.get(savePost.getId());
 
         // then
-        assertNotNull(post);
+        assertNotNull(postResponse);
         assertEquals(1L, postRepository.count());
-        assertEquals("ㅎㅇ", post.getTitle());
-        assertEquals("ㅎㅇㅎㅇ", post.getContent());
-    }
-
-    @Test
-    @DisplayName("글 1개 조회")
-    void test4() throws Exception {
-        // given
-        Post post = Post.builder()
-                .title("ㅎㅇㅎㅇ")
-                .content("ㅎㅇ")
-                .build();
-
-        postRepository.save(post);
-
-        // expected
-        mockMvc.perform(get("/posts/{postId}", post.getId())
-                        .contentType(APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(post.getId()))
-                .andExpect(jsonPath("$.title").value("ㅎㅇㅎㅇ"))
-                .andExpect(jsonPath("$.content").value("ㅎㅇ"))
-                .andDo(print());
-
+        assertEquals("ㅎㅇ", postResponse.getTitle());
+        assertEquals("ㅎㅇㅎㅇ", postResponse.getContent());
     }
 }


### PR DESCRIPTION
게시물 반환을 위한 응답객체 설계(반환객체 내부 맴버변수에 값이 저장될때 제목은 10글자만 저장되도록 설계)
<img width="896" alt="스크린샷 2024-07-04 오후 4 07 29" src="https://github.com/mr6208/MySpring/assets/93671010/5ea14b61-37d3-48f8-8c93-685f686e923c">

서비스 로직 내부 반환값 변경
<img width="749" alt="스크린샷 2024-07-04 오후 4 08 06" src="https://github.com/mr6208/MySpring/assets/93671010/9262f205-1c6e-4599-bca3-30e669c45900">

테스크케이스 추가 수정
<img width="756" alt="스크린샷 2024-07-04 오후 4 08 27" src="https://github.com/mr6208/MySpring/assets/93671010/983d0b3f-58da-4a33-9e5d-8444f5601ef3">

